### PR TITLE
add support for mipsx and mips64 arch from bbolt

### DIFF
--- a/bolt_mips64x.go
+++ b/bolt_mips64x.go
@@ -1,0 +1,12 @@
+// +build mips64 mips64le
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x8000000000 // 512GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/bolt_mipsx.go
+++ b/bolt_mipsx.go
@@ -1,0 +1,12 @@
+// +build mips mipsle
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x40000000 // 1GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/boltdb/bolt
+
+go 1.12


### PR DESCRIPTION
This PR adds support for mips64, mips64le, mips and mipsle. Changes are backported from bbolt

The reason for this patch:
I'm trying to create an OpenWrt package for probe-cli (from ooni tools) which heavily use Psiphon-labs libraries. 

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>